### PR TITLE
query number of workers periodically

### DIFF
--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -94,6 +94,17 @@ class MonitorThread(threading.Thread):
                 time.sleep(5)
 
 
+class WorkerMonitoringThread(threading.Thread):
+    def __init__(self, *args, app=None, **kwargs):
+        self._app = app
+        super().__init__(*args, **kwargs)
+
+    def run(self):
+        while True:
+            WORKERS.set(len(self._app.control.ping(timeout=5)))
+            time.sleep(5)
+
+
 def setup_metrics():
     """
     This initializes the available metrics with default values so that
@@ -149,11 +160,16 @@ def main():
     signal.signal(signal.SIGTERM, shutdown)
 
     setup_metrics()
-    t = MonitorThread(app=celery.Celery(broker=opts.broker))
+    app = celery.Celery(broker=opts.broker)
+    t = MonitorThread(app=app)
     t.daemon = True
     t.start()
+    w = WorkerMonitoringThread(app=app)
+    w.daemon = True
+    w.start()
     start_httpd(opts.addr)
     t.join()
+    w.join()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Backported from @samber's [fork](https://github.com/samber/celery-prometheus-exporter/).

This fixes the issue where the monitor doesn't receive events anymore when the last worker node goes down and thus the WORKER gauge would stay at 1 forever.

I also investigated listening to the `worker-offline` event but in my tests the monitor never received it.