### PR TITLE
add argument --transport_options to configure broker transport

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Redis, take a look at the Celery documentation and install the additioinal
 requirements 😊 Also use the ``--broker`` option to specify a different broker
 URL.
 
-If you need to pass additional options to your brokers transport use the
+If you need to pass additional options to your broker's transport use the
 ``--transport_options``  option. It tries to read a dict from a JSON object.
 E.g. to set your master name when using Redis Sentinel for broker discovery:
 ``--transport_options '{"master_name": "mymaster"}'``

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,11 @@ Redis, take a look at the Celery documentation and install the additioinal
 requirements 😊 Also use the ``--broker`` option to specify a different broker
 URL.
 
+If you need to pass additional options to your brokers transport use the
+``--transport_options``  option. It tries to read a dict from a JSON object.
+E.g. to set your master name when using Redis Sentinel for broker discovery:
+``--transport_options '{"master_name": "mymaster"}'``
+
 If you then look at the exposed metrics, you should see something like this::
 
   $ http get http://localhost:8888/metrics | grep celery_

--- a/README.rst
+++ b/README.rst
@@ -44,9 +44,9 @@ requirements 😊 Also use the ``--broker`` option to specify a different broker
 URL.
 
 If you need to pass additional options to your broker's transport use the
-``--transport_options``  option. It tries to read a dict from a JSON object.
+``--transport-options``  option. It tries to read a dict from a JSON object.
 E.g. to set your master name when using Redis Sentinel for broker discovery:
-``--transport_options '{"master_name": "mymaster"}'``
+``--transport-options '{"master_name": "mymaster"}'``
 
 Use ``--tz`` to specify the timezone the Celery app is using. Otherwise the
 systems local time will be used.

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -8,6 +8,7 @@ import signal
 import sys
 import threading
 import time
+import json
 
 __VERSION__ = (1, 1, 0, 'final', 0)
 
@@ -130,6 +131,9 @@ def main():
         '--broker', dest='broker', default=DEFAULT_BROKER,
         help="URL to the Celery broker. Defaults to {}".format(DEFAULT_BROKER))
     parser.add_argument(
+        '--transport_options', dest='transport_options',
+        help="JSON object with additional options passed to the underlying transport.")
+    parser.add_argument(
         '--addr', dest='addr', default=DEFAULT_ADDR,
         help="Address the HTTPD should listen on. Defaults to {}".format(
             DEFAULT_ADDR))
@@ -149,7 +153,17 @@ def main():
     signal.signal(signal.SIGTERM, shutdown)
 
     setup_metrics()
-    t = MonitorThread(app=celery.Celery(broker=opts.broker))
+    app = celery.Celery(broker=opts.broker)
+    if opts.transport_options:
+        try:
+            transport_options = json.loads(opts.transport_options)
+        except ValueError:
+            print("Error parsing broker transport options from JSON '{}'"
+                  .format(opts.transport_options))
+            return
+        else:
+            app.conf.broker_transport_options = transport_options
+    t = MonitorThread(app=app)
     t.daemon = True
     t.start()
     start_httpd(opts.addr)

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -143,7 +143,7 @@ def main():
         '--broker', dest='broker', default=DEFAULT_BROKER,
         help="URL to the Celery broker. Defaults to {}".format(DEFAULT_BROKER))
     parser.add_argument(
-        '--transport_options', dest='transport_options',
+        '--transport-options', dest='transport_options',
         help="JSON object with additional options passed to the underlying transport.")
     parser.add_argument(
         '--addr', dest='addr', default=DEFAULT_ADDR,


### PR DESCRIPTION
This PR adds a new argument `--transport_options` which allows to pass additional parameters to the brokers transport.