### PR TITLE
allow to configure timezone

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,9 @@ Redis, take a look at the Celery documentation and install the additioinal
 requirements 😊 Also use the ``--broker`` option to specify a different broker
 URL.
 
+Use ``--tz`` to specify the timezone the Celery app is using. Otherwise the
+systems local time will be used.
+
 If you then look at the exposed metrics, you should see something like this::
 
   $ http get http://localhost:8888/metrics | grep celery_

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -8,6 +8,7 @@ import signal
 import sys
 import threading
 import time
+import os
 
 __VERSION__ = (1, 1, 0, 'final', 0)
 
@@ -134,6 +135,9 @@ def main():
         help="Address the HTTPD should listen on. Defaults to {}".format(
             DEFAULT_ADDR))
     parser.add_argument(
+        '--tz', dest='tz',
+        help="Timezone used by the celery app.")
+    parser.add_argument(
         '--verbose', action='store_true', default=False,
         help="Enable verbose logging")
     parser.add_argument(
@@ -147,6 +151,10 @@ def main():
 
     signal.signal(signal.SIGINT, shutdown)
     signal.signal(signal.SIGTERM, shutdown)
+
+    if opts.tz:
+        os.environ['TZ'] = opts.tz
+        time.tzset()
 
     setup_metrics()
     t = MonitorThread(app=celery.Celery(broker=opts.broker))


### PR DESCRIPTION
This PR adds a argument to configure the timezone the monitor app should use. 

This solves a problem where the Celery app is using a timezone different from the hosts local time.
 (Which would result in workers being considered constantly dead if the timezone offset was negative)