### PR TITLE
optimize task metrics collection

### DIFF
--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -73,7 +73,8 @@ class MonitorThread(threading.Thread):
         else:
             # ignore latency if it is a retry
             if prev_evt.state == celery.states.RECEIVED:
-                LATENCY.observe(evt['local_received'] - prev_evt.local_received)
+                LATENCY.observe(
+                    evt['local_received'] - prev_evt.local_received)
 
     def _collect_tasks(self, evt, state):
         if state in celery.states.READY_STATES:
@@ -172,7 +173,8 @@ def main():  # pragma: no cover
         help="URL to the Celery broker. Defaults to {}".format(DEFAULT_BROKER))
     parser.add_argument(
         '--transport-options', dest='transport_options',
-        help="JSON object with additional options passed to the underlying transport.")
+        help=("JSON object with additional options passed to the underlying "
+              "transport."))
     parser.add_argument(
         '--addr', dest='addr', default=DEFAULT_ADDR,
         help="Address the HTTPD should listen on. Defaults to {}".format(

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -68,7 +68,7 @@ class TestMockedCelery(TestCase):
         assert REGISTRY.get_sample_value('celery_task_latency_count') == 0
         assert REGISTRY.get_sample_value('celery_task_latency_sum') == 0
 
-        m._process_task_received(Event(
+        m._process_event(Event(
             'task-received', uuid=task_uuid, name=task_name,
             args='()', kwargs='{}', retries=0, eta=None, hostname=hostname,
             clock=0,
@@ -82,7 +82,7 @@ class TestMockedCelery(TestCase):
             assert REGISTRY.get_sample_value(
                 'celery_tasks', labels=dict(state=state)) == 1
 
-        m._process_task_started(Event(
+        m._process_event(Event(
             'task-started', uuid=task_uuid, hostname=hostname,
             clock=1,
             local_received=local_received + latency_before_started))


### PR DESCRIPTION
- remove tasks from self._state.tasks once they reach one of the READY_STATES (SUCCESS, FAILURE, REVOKED)
- use .inc() for task gauge with READY_STATES labels because they can't go down
- don't use separate event listeners for `task-received` and `task-started`
- don't use a separate dict to gather task latency information