### PR TITLE
Add label 'name' to tasks metric

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,9 @@ standalone-service to make reuse easier across different frameworks.
 So far it provides access to the following metrics:
 
 * ``celery_tasks`` exposes the number of tasks currently known to the queue
-  grouped by ``name`` and ``state`` (RECEIVED, STARTED, ...).
+  grouped by ``state`` (RECEIVED, STARTED, ...).
+* ``celery_tasks_by_name`` exposes the number of tasks currently known to the queue
+  grouped by ``name`` and ``state``.
 * ``celery_workers`` exposes the number of currently probably alive workers
 * ``celery_task_latency`` exposes a histogram of task latency, i.e. the time until
   tasks are picked up by a worker
@@ -60,20 +62,29 @@ If you then look at the exposed metrics, you should see something like this::
   celery_workers 1.0
   # HELP celery_tasks Number of tasks per state
   # TYPE celery_tasks gauge
-  celery_tasks{name="my_app.tasks.calculate_something",state="RECEIVED"} 0.0
-  celery_tasks{name="my_app.tasks.calculate_something",state="PENDING"} 0.0
-  celery_tasks{name="my_app.tasks.calculate_something",state="STARTED"} 0.0
-  celery_tasks{name="my_app.tasks.calculate_something",state="RETRY"} 0.0
-  celery_tasks{name="my_app.tasks.calculate_something",state="FAILURE"} 0.0
-  celery_tasks{name="my_app.tasks.calculate_something",state="REVOKED"} 0.0
-  celery_tasks{name="my_app.tasks.calculate_something",state="SUCCESS"} 1.0
-  celery_tasks{name="my_app.tasks.fetch_some_data",state="RECEIVED"} 3.0
-  celery_tasks{name="my_app.tasks.fetch_some_data",state="PENDING"} 0.0
-  celery_tasks{name="my_app.tasks.fetch_some_data",state="STARTED"} 1.0
-  celery_tasks{name="my_app.tasks.fetch_some_data",state="RETRY"} 2.0
-  celery_tasks{name="my_app.tasks.fetch_some_data",state="FAILURE"} 1.0
-  celery_tasks{name="my_app.tasks.fetch_some_data",state="REVOKED"} 0.0
-  celery_tasks{name="my_app.tasks.fetch_some_data",state="SUCCESS"} 7.0
+  celery_tasks{state="RECEIVED"} 3.0
+  celery_tasks{state="PENDING"} 0.0
+  celery_tasks{state="STARTED"} 1.0
+  celery_tasks{state="RETRY"} 2.0
+  celery_tasks{state="FAILURE"} 1.0
+  celery_tasks{state="REVOKED"} 0.0
+  celery_tasks{state="SUCCESS"} 8.0
+  # HELP celery_tasks_by_name Number of tasks per state
+  # TYPE celery_tasks_by_name gauge
+  celery_tasks_by_name{name="my_app.tasks.calculate_something",state="RECEIVED"} 0.0
+  celery_tasks_by_name{name="my_app.tasks.calculate_something",state="PENDING"} 0.0
+  celery_tasks_by_name{name="my_app.tasks.calculate_something",state="STARTED"} 0.0
+  celery_tasks_by_name{name="my_app.tasks.calculate_something",state="RETRY"} 0.0
+  celery_tasks_by_name{name="my_app.tasks.calculate_something",state="FAILURE"} 0.0
+  celery_tasks_by_name{name="my_app.tasks.calculate_something",state="REVOKED"} 0.0
+  celery_tasks_by_name{name="my_app.tasks.calculate_something",state="SUCCESS"} 1.0
+  celery_tasks_by_name{name="my_app.tasks.fetch_some_data",state="RECEIVED"} 3.0
+  celery_tasks_by_name{name="my_app.tasks.fetch_some_data",state="PENDING"} 0.0
+  celery_tasks_by_name{name="my_app.tasks.fetch_some_data",state="STARTED"} 1.0
+  celery_tasks_by_name{name="my_app.tasks.fetch_some_data",state="RETRY"} 2.0
+  celery_tasks_by_name{name="my_app.tasks.fetch_some_data",state="FAILURE"} 1.0
+  celery_tasks_by_name{name="my_app.tasks.fetch_some_data",state="REVOKED"} 0.0
+  celery_tasks_by_name{name="my_app.tasks.fetch_some_data",state="SUCCESS"} 7.0
   # HELP celery_task_latency Seconds between a task is received and started.
   # TYPE celery_task_latency histogram
   celery_task_latency_bucket{le="0.005"} 2.0

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ standalone-service to make reuse easier across different frameworks.
 So far it provides access to the following metrics:
 
 * ``celery_tasks`` exposes the number of tasks currently known to the queue
-  seperated by ``state`` (RUNNING, STARTED, ...).
+  grouped by ``name`` and ``state`` (RECEIVED, STARTED, ...).
 * ``celery_workers`` exposes the number of currently probably alive workers
 * ``celery_task_latency`` exposes a histogram of task latency, i.e. the time until
   tasks are picked up by a worker
@@ -54,32 +54,39 @@ If you then look at the exposed metrics, you should see something like this::
   celery_workers 1.0
   # HELP celery_tasks Number of tasks per state
   # TYPE celery_tasks gauge
-  celery_tasks{state="PENDING"} 0.0
-  celery_tasks{state="STARTED"} 0.0
-  celery_tasks{state="SUCCESS"} 0.0
-  celery_tasks{state="FAILURE"} 0.0
-  celery_tasks{state="RECEIVED"} 0.0
-  celery_tasks{state="REVOKED"} 0.0
-  celery_tasks{state="RETRY"} 0.0
+  celery_tasks{name="my_app.tasks.calculate_something",state="RECEIVED"} 0.0
+  celery_tasks{name="my_app.tasks.calculate_something",state="PENDING"} 0.0
+  celery_tasks{name="my_app.tasks.calculate_something",state="STARTED"} 0.0
+  celery_tasks{name="my_app.tasks.calculate_something",state="RETRY"} 0.0
+  celery_tasks{name="my_app.tasks.calculate_something",state="FAILURE"} 0.0
+  celery_tasks{name="my_app.tasks.calculate_something",state="REVOKED"} 0.0
+  celery_tasks{name="my_app.tasks.calculate_something",state="SUCCESS"} 1.0
+  celery_tasks{name="my_app.tasks.fetch_some_data",state="RECEIVED"} 3.0
+  celery_tasks{name="my_app.tasks.fetch_some_data",state="PENDING"} 0.0
+  celery_tasks{name="my_app.tasks.fetch_some_data",state="STARTED"} 1.0
+  celery_tasks{name="my_app.tasks.fetch_some_data",state="RETRY"} 2.0
+  celery_tasks{name="my_app.tasks.fetch_some_data",state="FAILURE"} 1.0
+  celery_tasks{name="my_app.tasks.fetch_some_data",state="REVOKED"} 0.0
+  celery_tasks{name="my_app.tasks.fetch_some_data",state="SUCCESS"} 7.0
   # HELP celery_task_latency Seconds between a task is received and started.
   # TYPE celery_task_latency histogram
-  celery_task_latency_bucket{le="0.005"} 0.0
-  celery_task_latency_bucket{le="0.01"} 0.0
-  celery_task_latency_bucket{le="0.025"} 0.0
-  celery_task_latency_bucket{le="0.05"} 0.0
-  celery_task_latency_bucket{le="0.075"} 0.0
-  celery_task_latency_bucket{le="0.1"} 0.0
-  celery_task_latency_bucket{le="0.25"} 0.0
-  celery_task_latency_bucket{le="0.5"} 0.0
-  celery_task_latency_bucket{le="0.75"} 0.0
-  celery_task_latency_bucket{le="1.0"} 0.0
-  celery_task_latency_bucket{le="2.5"} 0.0
-  celery_task_latency_bucket{le="5.0"} 0.0
-  celery_task_latency_bucket{le="7.5"} 0.0
-  celery_task_latency_bucket{le="10.0"} 0.0
-  celery_task_latency_bucket{le="+Inf"} 0.0
-  celery_task_latency_count 0.0
-  celery_task_latency_sum 0.0
+  celery_task_latency_bucket{le="0.005"} 2.0
+  celery_task_latency_bucket{le="0.01"} 3.0
+  celery_task_latency_bucket{le="0.025"} 4.0
+  celery_task_latency_bucket{le="0.05"} 4.0
+  celery_task_latency_bucket{le="0.075"} 5.0
+  celery_task_latency_bucket{le="0.1"} 5.0
+  celery_task_latency_bucket{le="0.25"} 5.0
+  celery_task_latency_bucket{le="0.5"} 5.0
+  celery_task_latency_bucket{le="0.75"} 5.0
+  celery_task_latency_bucket{le="1.0"} 5.0
+  celery_task_latency_bucket{le="2.5"} 8.0
+  celery_task_latency_bucket{le="5.0"} 11.0
+  celery_task_latency_bucket{le="7.5"} 11.0
+  celery_task_latency_bucket{le="10.0"} 11.0
+  celery_task_latency_bucket{le="+Inf"} 11.0
+  celery_task_latency_count 11.0
+  celery_task_latency_sum 16.478713035583496
 
 
 Limitations

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -231,7 +231,6 @@ def main():  # pragma: no cover
         time.tzset()
 
     app = celery.Celery(broker=opts.broker)
-    setup_metrics(app)
 
     if opts.transport_options:
         try:
@@ -242,6 +241,8 @@ def main():  # pragma: no cover
             sys.exit(1)
         else:
             app.conf.broker_transport_options = transport_options
+
+    setup_metrics(app)
 
     t = MonitorThread(app=app)
     t.daemon = True

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -91,7 +91,7 @@ class MonitorThread(threading.Thread):
             self._state.tasks.pop(evt['uuid'])
         except KeyError:  # pragma: no cover
             pass
-        TASKS.labels(state).inc()
+        TASKS.labels(state=state, name=evt['name']).inc()
 
     def _collect_unready_tasks(self):
         cnt = collections.Counter(
@@ -153,7 +153,7 @@ def setup_metrics(app):
     WORKERS.set(0)
     try:
         registered_tasks = app.control.inspect().registered_tasks().values()
-    except Exception as e:
+    except Exception:  # pragma: no cover
         for metric in TASKS.collect():
             for name, labels, cnt in metric.samples:
                 TASKS.labels(**labels).set(0)

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -96,7 +96,10 @@ class MonitorThread(threading.Thread):
         except KeyError:  # pragma: no cover
             pass
         TASKS.labels(state=state).inc()
-        TASKS_NAME.labels(state=state, name=evt['name']).inc()
+        try:
+            TASKS_NAME.labels(state=state, name=evt['name']).inc()
+        except KeyError:  # pragma: no cover
+            pass
 
     def _collect_unready_tasks(self):
         # count unready tasks by state

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,2 @@
 redis==2.10.5
-prometheus_client==0.0.13
+prometheus_client==0.0.20

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     install_requires=[
         'celery>=3',
-        'prometheus_client',
+        'prometheus_client>=0.0.20',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This PR adds a second label `name` to the `celery_tasks` metric.