### PR TITLE
task-succeeded events don't contain the task name, fixes #14

### DIFF
--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -90,15 +90,12 @@ class MonitorThread(threading.Thread):
         self._collect_unready_tasks()
 
     def _incr_ready_task(self, evt, state):
-        try:
-            # remove event from list of in-progress tasks
-            self._state.tasks.pop(evt['uuid'])
-        except KeyError:  # pragma: no cover
-            pass
         TASKS.labels(state=state).inc()
         try:
-            TASKS_NAME.labels(state=state, name=evt['name']).inc()
-        except KeyError:  # pragma: no cover
+            # remove event from list of in-progress tasks
+            event = self._state.tasks.pop(evt['uuid'])
+            TASKS_NAME.labels(state=state, name=event.name).inc()
+        except (KeyError, AttributeError):  # pragma: no cover
             pass
 
     def _collect_unready_tasks(self):

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -79,7 +79,7 @@ class TestMockedCelery(TestCase):
         self._assert_all_states({celery.states.STARTED})
 
         m._process_event(Event(
-            'task-succeeded', uuid=task_uuid, result='42', name=self.task,
+            'task-succeeded', uuid=task_uuid, result='42',
             runtime=runtime, hostname=hostname, clock=2,
             local_received=local_received + latency_before_started + runtime))
         self._assert_all_states({celery.states.SUCCESS})


### PR DESCRIPTION
The events which Celery send when a task succeeds, do not contain the name of the task. With this PR we use the name from the internally stored event from the task-started event.