### PR TITLE
Find worker count based on ping only, not events state

### DIFF
--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -67,8 +67,6 @@ class MonitorThread(threading.Thread):
                 if state == celery.states.STARTED:
                     self._observe_latency(evt)
                 self._collect_tasks(evt, state)
-            WORKERS.set(
-                len([w for w in self._state.workers.values() if w.alive]))
 
     def _observe_latency(self, evt):
         try:


### PR DESCRIPTION
When running with celery3, worker count would always be collected by
prometheus as 0. By manually querying celery-prometheus-exporter several
times per second, I found out that once every ~10 seconds, the count
would be correct (2 in my case), but tenths of a second later it would
revert to 0 and stay like that for several seconds. I modified the code
and entered log statements, and I realized that the lines removed on
this commit would always for some weird reason set the counter to 0.

Since #7, there is a periodic celery `app.control.ping` in
`WorkerMonitoringThread` https://github.com/zerok/celery-prometheus-exporter/blob/86686ad6e1015bb9e2a66bbf31e0555712d087d3/celery_prometheus_exporter.py#L147-L149 which also sets the workers count. In my case,
this would always discover the correct number.

Since in my case, the `celery.events.state` based worker count discovery
didn't work and since having two jobs updating the same counter seems
redundant, I removed these lines.