### PR TITLE
Add cli flag to enable events on workers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,12 @@ whatever other dependencies you will need for it to speak with your broker 🙂
 Celery workers have to be configured to send task-related events:
 http://docs.celeryproject.org/en/latest/userguide/configuration.html#worker-send-task-events.
 
+Running ``celery-prometheus-exporter`` with the ``--enable-events`` argument
+will periodically enable events on the workers. This is useful because it
+allows running celery workers with events disabled, until
+``celery-prometheus-exporter`` is deployed, at which time events get enabled
+on the workers.
+
 Alternatively, you can use the bundle Makefile and Dockerfile to generate a
 Docker image.
 

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -154,11 +154,15 @@ class EnableEventsThread(threading.Thread):
 
     def __init__(self, *args, app=None, **kwargs):
         self._app = app
+        self.log = logging.getLogger('enable-events')
         super().__init__(*args, **kwargs)
 
     def run(self):  # pragma: no cover
         while True:
-            self._app.control.enable_events()
+            try:
+                self._app.control.enable_events()
+            except Exception as exc:
+                self.log.error("Error while trying to enable events: %r", exc)
             time.sleep(self.periodicity_seconds)
 
 


### PR DESCRIPTION
Add `--enable-events` CLI argument, which causes
celery-prometheus-exporter to periodically enable events on workers.

This is useful because it allows running celery workers with events
disabled, until `celery-prometheus-exporter` is deployed, at which time
events get enabled on the workers.

Celery Flower does the same thing. Except there, this is the default
behavior. In this case I made it opt-in to keep previous behavior.