### PR TITLE
Added Histogram 'runtime' metric for successfully-completed tasks.

### DIFF
--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -28,8 +28,8 @@ TASKS = prometheus_client.Gauge(
 TASKS_NAME = prometheus_client.Gauge(
     'celery_tasks_by_name', 'Number of tasks per state and name',
     ['state', 'name'])
-TASKS_RUNTIME_BY_NAME = prometheus_client.Histogram(
-    'celery_tasks_runtime_by_name', 'Task runtime per name',
+TASKS_RUNTIME = prometheus_client.Histogram(
+    'celery_tasks_runtime', 'Task runtime',
     ['name'])
 WORKERS = prometheus_client.Gauge(
     'celery_workers', 'Number of alive workers')
@@ -100,8 +100,8 @@ class MonitorThread(threading.Thread):
             event = self._state.tasks.pop(evt['uuid'])
             TASKS_NAME.labels(state=state, name=event.name).inc()
             if 'runtime' in evt:
-                TASKS_RUNTIME_BY_NAME.labels(name=event.name) \
-                                     .observe(evt['runtime'])
+                TASKS_RUNTIME.labels(name=event.name) \
+                             .observe(evt['runtime'])
         except (KeyError, AttributeError):  # pragma: no cover
             pass
 

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -28,6 +28,9 @@ TASKS = prometheus_client.Gauge(
 TASKS_NAME = prometheus_client.Gauge(
     'celery_tasks_by_name', 'Number of tasks per state and name',
     ['state', 'name'])
+TASKS_RUNTIME_BY_NAME = prometheus_client.Histogram(
+    'celery_tasks_runtime_by_name', 'Task runtime per name',
+    ['name'])
 WORKERS = prometheus_client.Gauge(
     'celery_workers', 'Number of alive workers')
 LATENCY = prometheus_client.Histogram(
@@ -96,6 +99,9 @@ class MonitorThread(threading.Thread):
             # remove event from list of in-progress tasks
             event = self._state.tasks.pop(evt['uuid'])
             TASKS_NAME.labels(state=state, name=event.name).inc()
+            if 'runtime' in evt:
+                TASKS_RUNTIME_BY_NAME.labels(name=event.name) \
+                                     .observe(evt['runtime'])
         except (KeyError, AttributeError):  # pragma: no cover
             pass
 

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -29,7 +29,7 @@ TASKS_NAME = prometheus_client.Gauge(
     'celery_tasks_by_name', 'Number of tasks per state and name',
     ['state', 'name'])
 TASKS_RUNTIME = prometheus_client.Histogram(
-    'celery_tasks_runtime', 'Task runtime',
+    'celery_tasks_runtime_seconds', 'Task runtime (seconds)',
     ['name'])
 WORKERS = prometheus_client.Gauge(
     'celery_workers', 'Number of alive workers')

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -92,10 +92,10 @@ class TestMockedCelery(TestCase):
         self.assertAlmostEqual(REGISTRY.get_sample_value(
             'celery_task_latency_sum'), latency_before_started)
         assert REGISTRY.get_sample_value(
-            'celery_tasks_runtime_by_name_count',
+            'celery_tasks_runtime_count',
             labels=dict(name=self.task)) == 1
         assert REGISTRY.get_sample_value(
-            'celery_tasks_runtime_by_name_sum',
+            'celery_tasks_runtime_sum',
             labels=dict(name=self.task)) == 234.5
 
     def test_enable_events(self):

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -91,6 +91,12 @@ class TestMockedCelery(TestCase):
         assert REGISTRY.get_sample_value('celery_task_latency_count') == 1
         self.assertAlmostEqual(REGISTRY.get_sample_value(
             'celery_task_latency_sum'), latency_before_started)
+        assert REGISTRY.get_sample_value(
+            'celery_tasks_runtime_by_name_count',
+            labels=dict(name=self.task)) == 1
+        assert REGISTRY.get_sample_value(
+            'celery_tasks_runtime_by_name_sum',
+            labels=dict(name=self.task)) == 234.5
 
     def test_enable_events(self):
         with patch.object(self.app.control, 'enable_events') as mock_enable_events:

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -92,10 +92,10 @@ class TestMockedCelery(TestCase):
         self.assertAlmostEqual(REGISTRY.get_sample_value(
             'celery_task_latency_sum'), latency_before_started)
         assert REGISTRY.get_sample_value(
-            'celery_tasks_runtime_count',
+            'celery_tasks_runtime_seconds_count',
             labels=dict(name=self.task)) == 1
         assert REGISTRY.get_sample_value(
-            'celery_tasks_runtime_sum',
+            'celery_tasks_runtime_seconds_sum',
             labels=dict(name=self.task)) == 234.5
 
     def test_enable_events(self):


### PR DESCRIPTION
I'm finding the need to report on Celery task-execution time, which is provided by the `runtime` metric returned for successful tasks (only).  This PR adds that metric, and a test.

runtime is the time it took to execute the task using the pool.
(Starting from the task is sent to the worker pool, and ending
when the pool result handler callback is called).

This metric is not recorded by state, as Celery only provides
the runtime metric for successfully completed tasks.