### PR TITLE
Add possibility to set custom buckets for histograms

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,14 @@ E.g. to set your master name when using Redis Sentinel for broker discovery:
 Use ``--tz`` to specify the timezone the Celery app is using. Otherwise the
 systems local time will be used.
 
+By default, buckets for histograms are the same as default ones in the prometheus client:
+https://github.com/prometheus/client_python#histogram.
+It means they are intended to cover typical web/rpc requests from milliseconds to seconds,
+so you may want to customize them.
+It can be done via environment variable ``RUNTIME_HISTOGRAM_BUCKETS`` for tasks runtime and
+via environment variable ``LATENCY_HISTOGRAM_BUCKETS`` for tasks latency.
+Buckets should be passed as a list of float values separated by a comma.
+E.g. ``".005, .05, 0.1, 1.0, 2.5"``.
 
 If you then look at the exposed metrics, you should see something like this::
 

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -17,10 +17,17 @@ import os
 __VERSION__ = (1, 2, 0, 'final', 0)
 
 
+def decode_buckets(buckets_list):
+    return [float(x) for x in buckets_list.split(',')]
+
+
+DEFAULT_BUCKETS = '.005, .01, .025, .05, .075, .1, .25, .5, .75, 1.0, 2.5, 5.0, 7.5, 10.0'
 DEFAULT_BROKER = os.environ.get('BROKER_URL', 'redis://redis:6379/0')
 DEFAULT_ADDR = os.environ.get('DEFAULT_ADDR', '0.0.0.0:8888')
 DEFAULT_MAX_TASKS_IN_MEMORY = int(os.environ.get('DEFAULT_MAX_TASKS_IN_MEMORY',
                                                  '10000'))
+RUNTIME_HISTOGRAM_BUCKETS = decode_buckets(os.environ.get('RUNTIME_HISTOGRAM_BUCKETS', DEFAULT_BUCKETS))
+LATENCY_HISTOGRAM_BUCKETS = decode_buckets(os.environ.get('LATENCY_HISTOGRAM_BUCKETS', DEFAULT_BUCKETS))
 
 LOG_FORMAT = '[%(asctime)s] %(name)s:%(levelname)s: %(message)s'
 
@@ -30,12 +37,11 @@ TASKS_NAME = prometheus_client.Gauge(
     'celery_tasks_by_name', 'Number of tasks per state and name',
     ['state', 'name'])
 TASKS_RUNTIME = prometheus_client.Histogram(
-    'celery_tasks_runtime_seconds', 'Task runtime (seconds)',
-    ['name'])
+    'celery_tasks_runtime_seconds', 'Task runtime (seconds)', ['name'], buckets=RUNTIME_HISTOGRAM_BUCKETS)
 WORKERS = prometheus_client.Gauge(
     'celery_workers', 'Number of alive workers')
 LATENCY = prometheus_client.Histogram(
-    'celery_task_latency', 'Seconds between a task is received and started.')
+    'celery_task_latency', 'Seconds between a task is received and started.', buckets=LATENCY_HISTOGRAM_BUCKETS)
 
 
 class MonitorThread(threading.Thread):

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -21,13 +21,20 @@ def decode_buckets(buckets_list):
     return [float(x) for x in buckets_list.split(',')]
 
 
-DEFAULT_BUCKETS = '.005, .01, .025, .05, .075, .1, .25, .5, .75, 1.0, 2.5, 5.0, 7.5, 10.0'
+def get_histogram_buckets_from_evn(env_name):
+    if env_name in os.environ:
+        buckets = decode_buckets(os.environ.get(env_name))
+    else:
+        buckets = prometheus_client.Histogram.DEFAULT_BUCKETS
+    return buckets
+
+
 DEFAULT_BROKER = os.environ.get('BROKER_URL', 'redis://redis:6379/0')
 DEFAULT_ADDR = os.environ.get('DEFAULT_ADDR', '0.0.0.0:8888')
 DEFAULT_MAX_TASKS_IN_MEMORY = int(os.environ.get('DEFAULT_MAX_TASKS_IN_MEMORY',
                                                  '10000'))
-RUNTIME_HISTOGRAM_BUCKETS = decode_buckets(os.environ.get('RUNTIME_HISTOGRAM_BUCKETS', DEFAULT_BUCKETS))
-LATENCY_HISTOGRAM_BUCKETS = decode_buckets(os.environ.get('LATENCY_HISTOGRAM_BUCKETS', DEFAULT_BUCKETS))
+RUNTIME_HISTOGRAM_BUCKETS = get_histogram_buckets_from_evn('RUNTIME_HISTOGRAM_BUCKET')
+LATENCY_HISTOGRAM_BUCKETS = get_histogram_buckets_from_evn('LATENCY_HISTOGRAM_BUCKET')
 
 LOG_FORMAT = '[%(asctime)s] %(name)s:%(levelname)s: %(message)s'
 


### PR DESCRIPTION
Histograms in Prometheus have default buckets ranges, which are suited for HTTP requests.
I would like to use them to measure tasks which can last up to one hour, so I've added a possibility to define custom buckets.