### PR TITLE
Queue Length Measurement Support

### DIFF
--- a/Dockerfile-celery4
+++ b/Dockerfile-celery4
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.6-alpine
 MAINTAINER Horst Gutmann <horst@zerokspot.com>
 
 RUN mkdir -p /app/requirements

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ E.g. to set your master name when using Redis Sentinel for broker discovery:
 Use ``--tz`` to specify the timezone the Celery app is using. Otherwise the
 systems local time will be used.
 
-Use ``--queue_list`` to specify the list of queues that will have its length
+Use ``--queue-list`` to specify the list of queues that will have its length
 monitored (Automatic Discovery of queues isn't supported right now, see limitations/
 caveats. You can use the `QUEUE_LIST` environment variable as well.
 

--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,9 @@ E.g. to set your master name when using Redis Sentinel for broker discovery:
 Use ``--tz`` to specify the timezone the Celery app is using. Otherwise the
 systems local time will be used.
 
+Use ``--queue_list`` to specify the list of queues that will have its length
+monitored (Automatic Discovery of queues isn't supported right now, see limitations/
+caveats. You can use the `QUEUE_LIST` environment variable as well.
 
 If you then look at the exposed metrics, you should see something like this::
 
@@ -118,7 +121,8 @@ If you then look at the exposed metrics, you should see something like this::
   celery_task_latency_bucket{le="+Inf"} 11.0
   celery_task_latency_count 11.0
   celery_task_latency_sum 16.478713035583496
-
+  celery_queue_length{queue_name="queue1"} 35.0
+  celery_queue_length{queue_name="queue2"} 0.0
 
 Limitations
 ===========
@@ -128,3 +132,5 @@ Limitations
   through the events API which might be enough to figure out the final queue,
   though.
 * This has only been tested with Redis so far.
+* At this point, you should specify the queues that will be monitored using an
+  environment variable or an arg (`--queue-list`).

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -196,7 +196,7 @@ class QueueLenghtMonitoringThread(threading.Thread):
     def __init__(self, app, queue_list):
         # type: (celery.Celery, [str]) -> None
         self.celery_app = app
-        self.queue_list=queue_list
+        self.queue_list = queue_list
         self.connection = self.celery_app.connection_or_acquire()
 
         if isinstance(self.connection, FallbackContext):
@@ -337,7 +337,13 @@ def main():  # pragma: no cover
     w.start()
 
     if opts.queue_list:
-        q = QueueLenghtMonitoringThread(app=app, queue_list=opts.queue_list)
+        if type(opts.queue_list) == str:
+            queue_list = opts.queue_list.split(',')
+        else:
+            queue_list = opts.queue_list
+
+        q = QueueLenghtMonitoringThread(app=app, queue_list=queue_list)
+
         q.daemon = True
         q.start()
 

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -41,7 +41,7 @@ WORKERS = prometheus_client.Gauge(
 LATENCY = prometheus_client.Histogram(
     'celery_task_latency', 'Seconds between a task is received and started.')
 QUEUE_LENGTH = prometheus_client.Gauge(
-    'celery_queue_length', 'Number of tasks in a redis queue.',
+    'celery_queue_length', 'Number of tasks in the queue.',
     ['queue_name']
 )
 
@@ -209,7 +209,7 @@ class QueueLenghtMonitoringThread(threading.Thread):
             try:
                 length = self.connection.default_channel.queue_declare(queue=queue, passive=True).message_count
             except (amqp.exceptions.ChannelError,) as e:
-                logging.warning("Queue Not Found: {}. Settings its value to zero. Error: {}".format(queue, str(e)))
+                logging.warning("Queue Not Found: {}. Setting its value to zero. Error: {}".format(queue, str(e)))
                 length = 0
 
             self.set_queue_length(queue, length)

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -39,7 +39,7 @@ WORKERS = prometheus_client.Gauge(
 LATENCY = prometheus_client.Histogram(
     'celery_task_latency', 'Seconds between a task is received and started.')
 QUEUE_LENGTH = prometheus_client.Gauge(
-    'celery_redis_queue_length', 'Number of tasks in a redis queue.',
+    'celery_queue_length', 'Number of tasks in a redis queue.',
     ['queue_name']
 )
 

--- a/celeryapp.py
+++ b/celeryapp.py
@@ -1,0 +1,41 @@
+from celery import Celery
+from kombu import Queue, Exchange
+
+import os
+import time
+
+BROKER_URL = os.getenv("BROKER_URL")
+RESULT_BACKEND_URL = os.getenv("RESULT_BACKEND_URL", None)
+
+celery_app = Celery(
+    broker=BROKER_URL,
+)
+
+if RESULT_BACKEND_URL:
+    celery_app.conf.update(backend=RESULT_BACKEND_URL)
+
+celery_app.conf.update(
+    CELERY_DEFAULT_QUEUE="queue1",
+    CELERY_QUEUES=(
+        Queue('queue1', exchange=Exchange('queue1', type='direct'), routing_key='queue1'),
+        Queue('queue2', exchange=Exchange('queue2', type='direct'), routing_key='queue2'),
+        Queue('queue3', exchange=Exchange('queue3', type='direct'), routing_key='queue3'),
+    ),
+    CELERY_ROUTES={
+        'task1': {'queue': 'queue1', 'routing_key': 'queue1'},
+        'task2': {'queue': 'queue2', 'routing_key': 'queue2'},
+        'task3': {'queue': 'queue3', 'routing_key': 'queue3'},
+    }
+)
+
+@celery_app.task
+def task1():
+    time.sleep(20)
+
+@celery_app.task
+def task2():
+    time.sleep(20)
+
+@celery_app.task
+def task3():
+    time.sleep(20)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '2'
+
+services:
+  app:
+    image: celery-exporter:3
+    build:
+      context: .
+      dockerfile: Dockerfile-celery3
+    user: "65534"
+    volumes:
+      - ./:/app
+    environment:
+    - BROKER_URL=amqp://rabbit
+    entrypoint: celery -A celeryapp worker
+
+  exporter:
+    image: celery-exporter:3
+    build:
+      context: .
+      dockerfile: Dockerfile-celery3
+    volumes:
+      - ./:/app
+    environment:
+    - BROKER_URL=amqp://rabbit
+    - QUEUE_LIST=queue1,queue2,queue3
+    ports:
+      - 8888:8888
+
+  cache:
+    image: redis:alpine
+
+  rabbit:
+    image: rabbitmq:alpine

--- a/test/celery_test_utils.py
+++ b/test/celery_test_utils.py
@@ -1,5 +1,27 @@
 import celery
+import time
+from kombu import Queue, Exchange
 
 
-def get_celery_app():
-    return celery.Celery(broker='memory://', backend='cache+memory://')
+def get_celery_app(queue=None):
+    app = celery.Celery(broker='memory://', backend='cache+memory://')
+
+    if queue:
+        app.conf.update(
+            CELERY_DEFAULT_QUEUE=queue,
+            CELERY_QUEUES=(
+                Queue(queue, exchange=Exchange(queue, type='direct'), routing_key=queue),
+            ),
+            CELERY_ROUTES={
+                'task1': {'queue': queue, 'routing_key': queue},
+            }
+        )
+
+    return app
+
+
+class SampleTask(celery.Task):
+    name = 'sample-task'
+
+    def run(self, *args, **kwargs):
+        time.sleep(10)

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -121,21 +121,17 @@ class TestMockedCelery(TestCase):
 
         sample_task.delay()
         monitoring_thread_instance.measure_queues_length()
-        samples = [sample for sample in QUEUE_LENGTH.collect()[0].samples if 'realqueue' in sample.labels['queue_name']]
+        sample = REGISTRY.get_sample_value('celery_queue_length', {'queue_name':'realqueue'})
 
-        self.assertEqual(1, len(samples))
-        self.assertEqual('realqueue', samples[0].labels['queue_name'])
-        self.assertEqual(1.0, samples[0].value)
+        self.assertEqual(1.0, sample)
 
     def test_set_zero_on_queue_length_when_an_channel_layer_error_occurs_during_queue_read(self):
         instance = QueueLenghtMonitoringThread(app=self.app, queue_list=['noqueue'])
 
         instance.measure_queues_length()
-        samples = [sample for sample in QUEUE_LENGTH.collect()[0].samples if 'noqueue' in sample.labels['queue_name']]
+        sample = REGISTRY.get_sample_value('celery_queue_length', {'queue_name':'noqueue'})
 
-        self.assertEqual(len(samples), 1)
-        self.assertEqual('noqueue', samples[0].labels['queue_name'])
-        self.assertEqual(0.0, samples[0].value)
+        self.assertEqual(0.0, sample)
 
     def _assert_task_states(self, states, cnt):
         for state in states:


### PR DESCRIPTION
### What Has Been Done

 - [x] Updated README doc 
 - [x] Implemented QueueLenghtMonitoringThread class with queue length monitoring support!
 - [x] Added an docker-compose.yaml that has been used to test the scenarios during development.
 - [x] Test coverage for the new class/metrics.
 - [x] Test with Celery 3 + PromTools 0.5.0
 - [x] Test with Celery 4 + PromTools 0.5.0 (A downgrade for python3.6 on docker image was needed because celery 4 + routes/queues are not supported with 3.7).
 - [x] Test with Celery 3 + PromTools 0.3.0
 - [x] Test with Celery 4 + PromTools 0.3.0

### Improvements

 * The solution has been tested with both redis and rabbitmq and works flawlessly.

### Questions

 * Should we initialize queue lengths in setup_metrics?

### Caveats

 * There is no support for automatic discovery of the queues, you need to specify it by using and environment var or arg;
 * When a queue doesn't exists and you try to read it, an amqp.ChannelError is returned even if you're using an redis or a memory backend  (Kombu things ...) o.O  Because of that, if an exception has been thrown during the read of the queue's length, its value will become 0 in the metrics endpoint and a logging message will be presented in the logs.

Relates to: https://github.com/zerok/celery-prometheus-exporter/issues/41