### PR TITLE
Freeze kombu version to avoid issues with redis-py version

### DIFF
--- a/requirements/celery4.txt
+++ b/requirements/celery4.txt
@@ -1,2 +1,3 @@
 -r base.txt
 celery==4.2.0
+kombu==4.3.0


### PR DESCRIPTION
### Context
The new [Kombu 4.4.0 release](https://github.com/celery/kombu/releases/tag/v4.4.0) requires ```redis-py>=3.2.0``` but Celery 4.2.0 requires  ```redis>=2.10.5,<3``` (see https://github.com/celery/celery/pull/5368)

So the Celery exporter for celery4 crashes:
```
kombu.exceptions.VersionMismatch: Redis transport requires redis-py versions 3.2.0 or later. You have 2.10.6
```

### Fix
Define a strict dependency for Kombu in Celery4 requirements.

---
cc @ldec